### PR TITLE
xerrors: adds IsOneOf

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -67,6 +67,24 @@ func Is(err, target error) bool {
 	}
 }
 
+// IsOneOf reports whether any error in the provided slice of errors matches the target.
+// IsOneOf looks at the entire error chain for each error and compares against the provided target.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func IsOneOf(errs []error, target error) bool {
+	isOneOf := false
+
+	for _, err := range errs {
+		if Is(err, target) {
+			isOneOf = true
+			break
+		}
+	}
+
+	return isOneOf
+}
+
 // As finds the first error in err's chain that matches the type to which target
 // points, and if so, sets the target to its value and returns true. An error
 // matches a type if it is assignable to the target type, or if it has a method

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -56,6 +56,34 @@ func TestIs(t *testing.T) {
 	}
 }
 
+func TestIsOneOf(t *testing.T) {
+	err1 := xerrors.New("1")
+	erra := xerrors.Errorf("wrap 2: %w", err1)
+	erro := xerrors.Opaque(err1)
+
+	poser := &poser{"either 1 or a", func(err error) bool {
+		return err == err1 || err == erra
+	}}
+
+	testCases := []struct {
+		errs   []error
+		target error
+		match  bool
+	}{
+		{[]error{nil, err1}, nil, true},
+		{[]error{err1, erro}, nil, false},
+		{[]error{erra, erro, err1, nil}, err1, true},
+		{[]error{poser, erra}, err1, true},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			if got := xerrors.IsOneOf(tc.errs, tc.target); got != tc.match {
+				t.Errorf("Is(%v, %v) = %v, want %v", tc.errs, tc.target, got, tc.match)
+			}
+		})
+	}
+}
+
 type poser struct {
 	msg string
 	f   func(error) bool


### PR DESCRIPTION
After reading [Proposal: Go 2 Error Inspection](https://go.googlesource.com/proposal/+/refs/changes/97/159497/3/design/XXXXX-error-values.md#proposal_go-2-error-inspection) I absolutely loved the introduction of the `Is` API.  I looked around some of my go codebases and immediately realized how it could improve readability by removing verbose equality checking.  After this exercise, I saw how the introduction of an `IsOneOf` API would further remove verbosity by allowing for the following change:

**Before**
```go
...
err := test.DoSomething()
if err == test.ErrExpected1 || err == test.ErrExpected2 || err == test.ErrExpected3 {
    return
}
...
```

**After**
```go
var expectedErrors = []errors{test.ErrExpected1, test.ErrExpected2,  test.ErrExpected3}
...
err := test.DoSomething()
if xerrors.IsOneOf(expectedErrors, err) {
    return
}
...
```

I believe the _After_ is both more terse and readable.  To that end, I have created this pull request. 